### PR TITLE
Add WebSocket support for real-time counter updates

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -4,6 +4,7 @@ go 1.22.2
 
 require (
 	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.4 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/server/handlers/websocket.go
+++ b/server/handlers/websocket.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/davidl21/counttomillion/server/data"
+	"github.com/gorilla/websocket"
+)
+
+type WebSocketHandler struct {
+	l *log.Logger
+	store *data.Store
+	clients map[*websocket.Conn]bool
+	broadcast chan []byte
+	mu *sync.Mutex
+	upgrader websocket.Upgrader
+}
+
+func NewWSHandler(l *log.Logger, s *data.Store) *WebSocketHandler {
+	return &WebSocketHandler{
+		l: l,
+		store: s,
+		clients: make(map[*websocket.Conn]bool),
+		broadcast: make(chan []byte),
+		mu: &sync.Mutex{},
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
+		},
+	}
+}
+
+func (ws *WebSocketHandler) HandleConnection(rw http.ResponseWriter, r *http.Request) {
+	conn, err := ws.upgrader.Upgrade(rw, r, nil)
+	if err != nil {
+		ws.l.Println("Error upgrading:", err)
+		return
+	}
+	defer conn.Close()
+
+	for {
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			ws.l.Println("Error reading message:", err)
+			break
+		}
+		ws.l.Println("Message received", message)
+		
+		if err := conn.WriteMessage(websocket.TextMessage, message); err != nil {
+		ws.l.Println("Error writing message:", err)
+			break
+		}
+	}
+}

--- a/server/handlers/websocket_test.go
+++ b/server/handlers/websocket_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestWebSocketIntegration(t *testing.T) {
+	l := log.New(os.Stdout, "test-ws", log.LstdFlags)
+	wsHandler := NewWSHandler(l, nil)
+	server := httptest.NewServer(http.HandlerFunc(wsHandler.HandleConnection))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+
+	t.Run("successful connection and message echo", func(t *testing.T) {
+		ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err != nil {
+			t.Fatalf("could not open websocket connection: %v", err)
+		}
+		defer ws.Close()
+
+		// test echo
+		testMessage := "test message"
+		err = ws.WriteMessage(websocket.TextMessage, []byte(testMessage))
+		if err != nil {
+			t.Fatalf("coudl not send message: %v", err)
+		}
+
+		// read response with timeout
+		done := make(chan bool)
+		go func() {
+			_, msg, err := ws.ReadMessage()
+			if err != nil {
+				t.Errorf("could not read message %v", err)
+				return
+			}
+			if string(msg) != testMessage {
+				t.Errorf("expected message %s, got message %s", testMessage, string(msg))
+			}
+			done <- true
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("test timeout")
+		}
+	})
+
+	t.Run("connection closes properly", func(t *testing.T) {
+		ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err != nil {
+			t.Fatalf("could not open websocket connection %v", err)
+		}
+
+		if err := ws.Close(); err != nil {
+			t.Errorf("error closing connection: %v", err)
+		}
+
+		err = ws.WriteMessage(websocket.TextMessage, []byte("test"))
+		if err == nil {
+			t.Error("expected error writing to closed ws connection")
+		}
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -34,9 +34,12 @@ func main() {
 	defer store.Close()
 
 	l := log.New(os.Stdout, "count-api ", log.LstdFlags)
+
 	countHandler := handlers.NewCount(l, store)
+	wsHandler := handlers.NewWSHandler(l, store)
 
 	serveMux := mux.NewRouter()
+	serveMux.HandleFunc("/ws", wsHandler.HandleConnection)
 
 	putRouter := serveMux.Methods(http.MethodPut).Subrouter()
 	putRouter.HandleFunc("/count", countHandler.IncrementCount)


### PR DESCRIPTION
**Summary**
Implements WebSocket functionality to enable real-time counter updates for multiple clients

- Added `WebSocketHandler` in order to  manage client connections and message broadcasts
- Implemented upgrader to upgrade HTTP to WebSocket
- Implemented basic message echo

**Testing**
Added integration test to verify:

- Successful HTTP to WebSocket upgrade
- Successful WebSocket server connection and message echo
- Successful WebSocket message read
- Successful connection close
- Handles edge case for writing to closed server

Ran tests with `go test ./server/handlers -run TestWebSocketIntegration`

**To-do**

- Implement client-side connection
- Implement client broadcasts